### PR TITLE
헬리콥터 로직 변경과 플레이어 이동 변경, 버그 수정

### DIFF
--- a/Assets/Script/Hook/Hook.cs
+++ b/Assets/Script/Hook/Hook.cs
@@ -64,6 +64,10 @@ public class Hook : MonoBehaviour
                 if (other.CompareTag("Helicopter"))
                 {
                     player.isHelicopter = true;
+
+                    // 헬리콥터에 갈고리가 걸리자마자 상승을 위해 Helicopter.cs에 갈고리가 걸렸다는 정보를 넘기는 메소드
+                    Helicopter heliCopterScript = other.GetComponentInParent<Helicopter>();
+                    heliCopterScript.PlayerHooked();
                 }
             }
         }


### PR DESCRIPTION
Helicopter now checks if it is hooked and ascends immediately when hooked, otherwise it is destroyed after waiting. Player is granted 3 seconds of invincibility with a blinking effect after dismounting from the helicopter, and collision handling is updated to respect this invincibility. Also fixes player lane assignment when hooking to streetlights and ensures proper state transitions.