### PR TITLE
버그 픽스

### DIFF
--- a/Assets/Script/Item/MagnetFunction.cs
+++ b/Assets/Script/Item/MagnetFunction.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 public class MagneticItem : MonoBehaviour
 {
     [Header("자석 설정")]
-    public float pullSpeed = 25.0f;
+    public float pullSpeed = 40.0f;
     public float magnetRange = 7.0f;
     public float collectDistance = 0.5f; 
 

--- a/Assets/Script/UI/PlayerAchivementList.cs
+++ b/Assets/Script/UI/PlayerAchivementList.cs
@@ -8,6 +8,8 @@ public class PlayerAchivementList : MonoBehaviour
 
     private List<AchievementDefinition> achievementDefinitions = new List<AchievementDefinition>();
 
+    private HashSet<string> sessionUnlockedIds = new HashSet<string>();
+
     void Awake()
     {
         if (Instance == null) Instance = this;
@@ -281,6 +283,13 @@ public class PlayerAchivementList : MonoBehaviour
     // 업적을 달성했는지 처리하는 함수
     private void UnlockAchievement(string achievementId, string title)
     {
+        if (sessionUnlockedIds.Contains(achievementId))
+        {
+            return; // 이미 처리된 업적이면 무시
+        }
+
+        sessionUnlockedIds.Add(achievementId);
+
         if (AchievementManager.Instance != null)
         {
             AchievementManager.Instance.UnlockAchievement(achievementId);


### PR DESCRIPTION
1. 자석 아이템 먹은 상태로 헬기를 탔을 때, 딸려오는 코인이 가리는 현상 -> 코인 자석 속도 높임
2. 차가 2번씩 충돌하는 현상 -> 차와 부딪히면 부모의 rigidbody를 확인하여 같다면 리턴
3. 모바일에서 release()안에 헬리콥터에 탑승했을 경우 리턴
4. jump() 등 플레이어 움직임에 변수를 달아서 iceman이 튜토리얼에서 적용되도록 수정
5. skyWalker를 확인하는 raycast의 길이 수정
6. playerAchievementList에서 업적 달성 중복 확인.